### PR TITLE
fix: Fix duration/time

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,20 +131,20 @@ The resulting JSON of the above example is:
 
 The resulting JUnit file of the above example is:
 ```
-<testsuites status="failed" tests="3" failures="1" skipped="1" time="369">
+<testsuites status="failed" tests="3" failures="1" skipped="1" time="0.369">
   <testsuite name="somegroup" status="failed" tests="0" failures="0" skipped="0" time="0">
     <properties>
       <property name="attachment" value="screenshot1.png">./screenshot1.png</property>
     </properties>
   </testsuite>
-  <testsuite name="somefile.test.js" status="failed" tests="3" failures="1" skipped="1" time="369">
-    <testcase name="yay" status="passed" time="123" timestamp="2023-06-20T21:32:07.467Z">
+  <testsuite name="somefile.test.js" status="failed" tests="3" failures="1" skipped="1" time="0.369">
+    <testcase name="yay" status="passed" time="0.123" timestamp="2023-06-20T21:32:07.467Z">
       <properties>
         <property name="attachment" value="video.mp4">./video.mp4</property>
         <property name="attachment" value="screenshot2.png">./screenshot2.png</property>
       </properties>
     </testcase>
-    <testcase name="nay" status="failed" time="123" timestamp="2023-06-20T21:32:07.467Z">
+    <testcase name="nay" status="failed" time="0.123" timestamp="2023-06-20T21:32:07.467Z">
       <properties>
         <property name="attachment" value="video.mp4">./video.mp4</property>
       </properties>
@@ -152,7 +152,7 @@ The resulting JUnit file of the above example is:
         <![CDATA[test failed]]>
       </failure>
     </testcase>
-    <testcase name="oops" status="skipped" time="123" timestamp="2023-06-20T21:32:07.467Z">
+    <testcase name="oops" status="skipped" time="0.123" timestamp="2023-06-20T21:32:07.467Z">
       <skipped>
         <![CDATA[test skipped]]>
       </skipped>

--- a/api/schema.json
+++ b/api/schema.json
@@ -59,7 +59,7 @@
           },
           "duration": {
             "type": "integer",
-            "description": "Duration of the test in seconds."
+            "description": "Duration of the test in milliseconds."
           },
           "output": {
             "type": "string",

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,7 +381,7 @@ export class Test {
         return new JUnitTestCase(
             this.name,
             this.status,
-            this.duration,
+            this.duration/1000.0,
             toProperty(this.attachments || [], this.metadata),
             // startTime should be a string in this case. Otherwise, XMLBuilder will not recognize the attribute name prefix.
             this.startTime.toISOString(),

--- a/tests/junit.test.ts
+++ b/tests/junit.test.ts
@@ -44,7 +44,7 @@ describe('toJUnitObj', function () {
         expect(jObj._tests).toBe(3)
         expect(jObj._failures).toBe(1)
         expect(jObj._skipped).toBe(1)
-        expect(jObj._time).toBe(369)
+        expect(jObj._time).toBe(0.369)
         expect(jObj.testsuite[0].testcase.length).toBe(0)
         expect(jObj.testsuite[0].properties).toBe(undefined)
         expect(jObj.testsuite[1].testcase.length).toBe(3)

--- a/tests/junit.test.ts
+++ b/tests/junit.test.ts
@@ -55,7 +55,7 @@ describe('toJUnitObj', function () {
         expect((jObj.testsuite[1].properties as any).property[2]._name).toBe('ids')
         expect((jObj.testsuite[1].properties as any).property[2]._value).toStrictEqual([1, 2, 3])
         expect(jObj.testsuite[1].testcase[0]._name).toBe('yay')
-        expect(jObj.testsuite[1].testcase[0]._time).toBe(123)
+        expect(jObj.testsuite[1].testcase[0]._time).toBe(0.123)
         expect(jObj.testsuite[1].testcase[1].failure).not.toBe(undefined)
         expect(jObj.testsuite[1].testcase[2].skipped).not.toBe(undefined)
     })


### PR DESCRIPTION
`sauce-test-report.json` should use milliseconds for `duration`.
`junit.xml` should use seconds for `time`.