### PR TITLE
build: package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@saucelabs/sauce-json-reporter",
   "version": "3.1.0",
-  "description": "",
+  "description": "A library for creating test results in the Sauce Labs JSON format.",
   "main": "lib/index.js",
   "exports": {
     ".": "./lib/index.js"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.1.0",
   "description": "",
   "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js"
+  },
   "types": "lib/index.d.ts",
   "files": [
     "lib/**"


### PR DESCRIPTION
Start using package exports. No real change to the visible scope, as we only ever had the one index file.